### PR TITLE
Fix macOS audio capture IPC and permissions

### DIFF
--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -3,6 +3,7 @@ actor User
 participant "Renderer Process" as R
 participant "Main Process" as M
 component "Kimi Module" as K
+component "SystemAudioDump" as SAD
 User -> R: Interact with UI
 R -> M: IPC events
 M -> K: OpenRouter requests
@@ -10,4 +11,6 @@ K -> "OpenRouter API": requests
 "OpenRouter API" --> K: responses
 K -> M: AI data
 M -> R: updates
+M -> SAD: start/stop audio
+SAD --> K: PCM stream
 @enduml

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -12,9 +12,11 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
-    <key>com.apple.security.device.microphone</key>
-    <true/>
-    <key>com.apple.security.network.client</key>
+  <key>com.apple.security.device.microphone</key>
+  <true/>
+  <key>com.apple.security.screen-recording</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -6,6 +6,7 @@
 
 ## Capture and Assistance
 - Continuous screen and audio capture provide context to the AI.
+- First use on macOS prompts for microphone and screen-record permissions.
 - Responses appear in real time within the transparent overlay.
 
 ## History and Profiles

--- a/forge.config.js
+++ b/forge.config.js
@@ -5,6 +5,7 @@ module.exports = {
     packagerConfig: {
         asar: true,
         extraResource: ['./src/assets/SystemAudioDump'],
+        extendInfo: './mac-info.plist',
         name: 'Cheating Daddy',
         icon: 'src/assets/logo',
         // use `security find-identity -v -p codesigning` to find your identity

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -7,7 +7,9 @@
 
 2. **Capture Workflow**
    - Renderer captures screen and audio.
+   - Renderer invokes `start-macos-audio` to spawn SystemAudioDump on macOS.
    - Chunks are sent via IPC (`send-audio-content`, `send-image-content`).
+   - Capture ends with `stop-macos-audio`.
    - Kimi module transcribes audio and forwards content to OpenRouter.
 
 3. **Response Handling**

--- a/mac-info.plist
+++ b/mac-info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Cheating Daddy needs microphone access to capture audio.</string>
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>Cheating Daddy requires screen recording permission to capture the screen.</string>
+</dict>
+</plist>

--- a/milestones.md
+++ b/milestones.md
@@ -3,3 +3,16 @@
 ## Milestone 1
 - Switch AI backend to OpenRouter Kimi-k2.
 - Update documentation and UI references.
+
+## Milestone 2 – macOS Capture Permissions
+- **Start:** 2025-07-25
+- **Target Finish:** 2025-08-02
+- **Status:** planned
+- **Objectives**
+  1. Ensure macOS audio capture works with proper permissions
+  2. Update documentation and package configuration
+
+### Task Roster
+| Task ID      | Title                                       | Status | Accountable | Due                |
+|--------------|---------------------------------------------|--------|------------|--------------------|
+| APP-BUG-101  | Fix macOS audio capture permissions and IPC | draft  | agent-A1   | 2025-08-01T23:00Z  |

--- a/src/utils/kimi.js
+++ b/src/utils/kimi.js
@@ -224,6 +224,29 @@ function setupKimiIpcHandlers(kimiSessionRef) {
         return sendTextMessage(text);
     });
 
+    ipcMain.handle('start-macos-audio', async () => {
+        if (process.platform !== 'darwin') {
+            return { success: false, error: 'macOS audio capture only available on macOS' };
+        }
+        try {
+            const success = await startMacOSAudioCapture();
+            return { success };
+        } catch (error) {
+            console.error('Error starting macOS audio capture:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('stop-macos-audio', async () => {
+        try {
+            stopMacOSAudioCapture();
+            return { success: true };
+        } catch (error) {
+            console.error('Error stopping macOS audio capture:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
     ipcMain.handle('close-session', async () => {
         openaiClient = null;
         kimiSessionRef.current = null;

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -1,1 +1,2 @@
 Please provide any feedback on the OpenRouter integration.
+Did the macOS permission dialogs for microphone and screen recording appear as expected?


### PR DESCRIPTION
## Summary
- add start/stop audio IPC handlers in kimi.js
- include macOS microphone and screen capture permission descriptions
- extend packager config for macOS Info.plist
- document macOS capture permissions and update milestone
- prompt subagents for permission feedback
- show SystemAudioDump in architecture diagram

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68818e33cfa0832ba0ebb2d6fc1021e7