### PR TITLE
BUG-101: register macOS audio ipc handlers

### DIFF
--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -6,6 +6,7 @@
 
 ## Capture and Assistance
 - Continuous screen and audio capture provide context to the AI.
+- macOS users benefit from dedicated system audio capture started via the `start-macos-audio` IPC channel.
 - Responses appear in real time within the transparent overlay.
 
 ## History and Profiles

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -7,6 +7,7 @@
 
 2. **Capture Workflow**
    - Renderer captures screen and audio.
+   - On macOS, the renderer invokes `start-macos-audio` so the main process spawns **SystemAudioDump** for system sound capture. Capture ends via `stop-macos-audio`.
    - Chunks are sent via IPC (`send-audio-content`, `send-image-content`).
    - Kimi module transcribes audio and forwards content to OpenRouter.
 

--- a/milestones.md
+++ b/milestones.md
@@ -3,3 +3,4 @@
 ## Milestone 1
 - Switch AI backend to OpenRouter Kimi-k2.
 - Update documentation and UI references.
+- Register macOS audio IPC handlers in `kimi.js`.

--- a/src/utils/kimi.js
+++ b/src/utils/kimi.js
@@ -224,7 +224,35 @@ function setupKimiIpcHandlers(kimiSessionRef) {
         return sendTextMessage(text);
     });
 
+    ipcMain.handle('start-macos-audio', async event => {
+        if (process.platform !== 'darwin') {
+            return {
+                success: false,
+                error: 'macOS audio capture only available on macOS',
+            };
+        }
+
+        try {
+            const success = await startMacOSAudioCapture();
+            return { success };
+        } catch (error) {
+            console.error('Error starting macOS audio capture:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('stop-macos-audio', async event => {
+        try {
+            stopMacOSAudioCapture();
+            return { success: true };
+        } catch (error) {
+            console.error('Error stopping macOS audio capture:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
     ipcMain.handle('close-session', async () => {
+        stopMacOSAudioCapture();
         openaiClient = null;
         kimiSessionRef.current = null;
         sendToRenderer('update-status', 'Session closed');

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -1,1 +1,2 @@
 Please provide any feedback on the OpenRouter integration.
+- Registered missing `start-macos-audio` and `stop-macos-audio` handlers to ensure macOS capture works.


### PR DESCRIPTION
## Summary
- hook up `start-macos-audio` and `stop-macos-audio` IPC in `kimi.js`
- mention macOS audio capture in the functional representation
- update the stakeholder feature overview with macOS audio capture
- note the fix in Milestone 1 documentation
- log feedback for the missing handlers

## Testing
- `npm start` *(fails: error while loading shared libraries libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_688197092870832b99cd2afde9d91754