### PR TITLE
Add Colleague profile and timestamp validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ A real-time AI assistant that provides contextual help during video calls, inter
 
 - **Live AI Assistance**: Real-time help powered by Google Gemini 2.0 Flash Live
 - **Screen & Audio Capture**: Analyzes what you see and hear for contextual responses
-- **Multiple Profiles**: Interview, Sales Call, Business Meeting, Presentation, Negotiation
+- **Multiple Profiles**: Interview, Sales Call, Business Meeting, Presentation, Negotiation, **Colleague**
 - **Transparent Overlay**: Always-on-top window that can be positioned anywhere
 - **Click-through Mode**: Make window transparent to clicks when needed
 - **Cross-platform**: Works on macOS, Windows, and Linux (kinda, dont use, just for testing rn)
+- **Validated Timestamps**: Conversation history now records times in `HH:MM:SS` format for each turn
 
 ## Setup
 

--- a/src/components/views/AssistantView.js
+++ b/src/components/views/AssistantView.js
@@ -323,6 +323,7 @@ export class AssistantView extends LitElement {
             presentation: 'Presentation',
             negotiation: 'Negotiation',
             exam: 'Exam Assistant',
+            colleague: 'Colleague',
         };
     }
 

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -491,6 +491,11 @@ export class CustomizeView extends LitElement {
                 name: 'Exam Assistant',
                 description: 'Academic assistance for test-taking and exam questions',
             },
+            {
+                value: 'colleague',
+                name: 'Colleague',
+                description: 'Interactive step guide',
+            },
         ];
     }
 
@@ -537,6 +542,7 @@ export class CustomizeView extends LitElement {
             presentation: 'Presentation',
             negotiation: 'Negotiation',
             exam: 'Exam Assistant',
+            colleague: 'Colleague',
         };
     }
 

--- a/src/components/views/HistoryView.js
+++ b/src/components/views/HistoryView.js
@@ -1,6 +1,11 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
 import { resizeLayout } from '../../utils/windowResize.js';
 
+// Access timestamp validation helper from main utils
+const { isValidHHMMSS } = window.require
+    ? window.require('../../utils/gemini.js')
+    : { isValidHHMMSS: () => false };
+
 export class HistoryView extends LitElement {
     static styles = css`
         * {
@@ -107,6 +112,12 @@ export class HistoryView extends LitElement {
 
         .message.ai {
             border-left-color: #ed4245; /* Discord red */
+        }
+
+        .message-time {
+            font-size: 10px;
+            color: var(--description-color);
+            margin-right: 6px;
         }
 
         .back-header {
@@ -408,6 +419,7 @@ export class HistoryView extends LitElement {
             presentation: 'Presentation',
             negotiation: 'Negotiation',
             exam: 'Exam Assistant',
+            colleague: 'Colleague',
         };
     }
 
@@ -504,14 +516,18 @@ export class HistoryView extends LitElement {
                     messages.push({
                         type: 'user',
                         content: turn.transcription,
-                        timestamp: turn.timestamp,
+                        timestamp: turn.formattedTimestamp && isValidHHMMSS(turn.formattedTimestamp)
+                            ? turn.formattedTimestamp
+                            : new Date(turn.timestamp).toISOString().slice(11, 19),
                     });
                 }
                 if (turn.ai_response) {
                     messages.push({
                         type: 'ai',
                         content: turn.ai_response,
-                        timestamp: turn.timestamp,
+                        timestamp: turn.formattedTimestamp && isValidHHMMSS(turn.formattedTimestamp)
+                            ? turn.formattedTimestamp
+                            : new Date(turn.timestamp).toISOString().slice(11, 19),
                     });
                 }
             });
@@ -546,7 +562,14 @@ export class HistoryView extends LitElement {
             </div>
             <div class="conversation-view">
                 ${messages.length > 0
-                    ? messages.map(message => html` <div class="message ${message.type}">${message.content}</div> `)
+                    ? messages.map(
+                          message => html`
+                              <div class="message ${message.type}">
+                                  <span class="message-time">${message.timestamp}</span>
+                                  ${message.content}
+                              </div>
+                          `
+                      )
                     : html`<div class="empty-state">No conversation data available</div>`}
             </div>
         `;

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -20,6 +20,10 @@ let maxReconnectionAttempts = 3;
 let reconnectionDelay = 2000; // 2 seconds between attempts
 let lastSessionParams = null;
 
+function isValidHHMMSS(str) {
+    return typeof str === 'string' && /^([0-1]\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(str);
+}
+
 function sendToRenderer(channel, data) {
     const windows = BrowserWindow.getAllWindows();
     if (windows.length > 0) {
@@ -40,8 +44,10 @@ function saveConversationTurn(transcription, aiResponse) {
         initializeNewSession();
     }
 
+    const iso = new Date().toISOString();
     const conversationTurn = {
-        timestamp: Date.now(),
+        timestamp: iso,
+        formattedTimestamp: iso.slice(11, 19),
         transcription: transcription.trim(),
         ai_response: aiResponse.trim(),
     };
@@ -670,4 +676,5 @@ module.exports = {
     sendAudioToGemini,
     setupGeminiIpcHandlers,
     attemptReconnection,
+    isValidHHMMSS,
 };

--- a/src/utils/prompts.js
+++ b/src/utils/prompts.js
@@ -199,6 +199,18 @@ You: "**Question**: Solve for x: 2x + 5 = 13 **Answer**: x = 4 **Why**: Subtract
         outputInstructions: `**OUTPUT INSTRUCTIONS:**
 Provide direct exam answers in **markdown format**. Include the question text, the correct answer choice, and a brief justification. Focus on efficiency and accuracy. Keep responses **short and to the point**.`,
     },
+
+    colleague: {
+        intro: `You are **Colleague**, an on-screen assistant that converts what the user sees into an interactive step-by-step guide.`,
+
+        formatRequirements: `**RESPONSE FORMAT REQUIREMENTS:**\n- Use **Markdown**\n- Present exactly one substep per response\n- Follow each step with a bold checkpoint question (A/B/C/D)`,
+
+        searchUsage: `**SEARCH TOOL USAGE:**\nUse Google search whenever the instructions rely on recent events, company details, or new technology.`,
+
+        content: `Build a timeline of on-screen actions and ask for clarification when needed. Provide concise, confirmation-driven guidance that mirrors the user's current context.`,
+
+        outputInstructions: `**OUTPUT INSTRUCTIONS:**\nTranslate the internal guide into Markdown. Never show raw JSON. Follow the Colleague interaction policy.`,
+    },
 };
 
 function buildSystemPrompt(promptParts, customPrompt = '', googleSearchEnabled = true) {


### PR DESCRIPTION
## Summary
- introduce **Colleague** prompt for interactive guides
- allow selecting the Colleague profile in customization view
- show Colleague name in history and assistant views
- store timestamps in ISO format and validate `HH:MM:SS`
- display message timestamps in conversation history
- document new profile and timestamp feature

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6886c3eebae4832b8a4fcb61519a20c5