### PR TITLE
Add colleague profile and timestamp validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A real-time AI assistant that provides contextual help during video calls, inter
 
 - **Live AI Assistance**: Real-time help powered by Google Gemini 2.0 Flash Live
 - **Screen & Audio Capture**: Analyzes what you see and hear for contextual responses
-- **Multiple Profiles**: Interview, Sales Call, Business Meeting, Presentation, Negotiation
+- **Multiple Profiles**: Interview, Sales Call, Business Meeting, Presentation, Negotiation, Colleague
+- **Timestamped History**: Conversation turns include precise `HH:MM:SS` timestamps
 - **Transparent Overlay**: Always-on-top window that can be positioned anywhere
 - **Click-through Mode**: Make window transparent to clicks when needed
 - **Cross-platform**: Works on macOS, Windows, and Linux (kinda, dont use, just for testing rn)

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -1,0 +1,7 @@
+# Dependency Graph
+
+This document lists major file relationships in the project.
+
+- `src/components/*` depend on `src/utils/*` for core logic.
+- `src/utils/gemini.js` interacts with Google Gemini and dispatches events to renderer.
+- Conversation data flows from `gemini.js` to renderer via IPC and is stored using functions in `src/utils/renderer.js`.

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -1,0 +1,11 @@
+# Feature Documentation
+
+This file describes features in simple terms for stakeholders.
+
+## Colleague Profile
+- Offers short, friendly suggestions like a helpful coworker.
+- Selectable from the Customize view.
+
+## Timestamped History
+- Each conversation turn now stores an exact `HH:MM:SS` timestamp.
+- History view only shows timestamps when valid, keeping older data uncluttered.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -1,0 +1,6 @@
+# Functional Representation
+
+This document summarizes new functionality for the colleague profile and timestamp validation.
+
+1. **Colleague Profile** — A friendly assistant mode for quick teamwork help.
+2. **Timestamp Validation** — Conversation turns include a `timestamp` (number) and `formattedTimestamp` (`HH:MM:SS`). History renders timestamps only when valid.

--- a/milestones.md
+++ b/milestones.md
@@ -1,0 +1,3 @@
+# Milestones
+
+- MILESTONE-1: Colleague profile and timestamp validation delivered.

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -487,6 +487,11 @@ export class CustomizeView extends LitElement {
                 description: 'Guidance for business negotiations and deals',
             },
             {
+                value: 'colleague',
+                name: 'Colleague',
+                description: 'Friendly help for everyday teamwork',
+            },
+            {
                 value: 'exam',
                 name: 'Exam Assistant',
                 description: 'Academic assistance for test-taking and exam questions',
@@ -536,6 +541,7 @@ export class CustomizeView extends LitElement {
             meeting: 'Business Meeting',
             presentation: 'Presentation',
             negotiation: 'Negotiation',
+            colleague: 'Colleague',
             exam: 'Exam Assistant',
         };
     }

--- a/src/components/views/HistoryView.js
+++ b/src/components/views/HistoryView.js
@@ -109,6 +109,12 @@ export class HistoryView extends LitElement {
             border-left-color: #ed4245; /* Discord red */
         }
 
+        .timestamp {
+            font-size: 9px;
+            color: var(--description-color);
+            margin-left: 6px;
+        }
+
         .back-header {
             display: flex;
             justify-content: space-between;
@@ -372,6 +378,10 @@ export class HistoryView extends LitElement {
         });
     }
 
+    isValidHHMMSS(str) {
+        return /^([01]\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(str || '');
+    }
+
     getSessionPreview(session) {
         if (!session.conversationHistory || session.conversationHistory.length === 0) {
             return 'No conversation yet';
@@ -407,6 +417,7 @@ export class HistoryView extends LitElement {
             meeting: 'Business Meeting',
             presentation: 'Presentation',
             negotiation: 'Negotiation',
+            colleague: 'Colleague',
             exam: 'Exam Assistant',
         };
     }
@@ -505,6 +516,7 @@ export class HistoryView extends LitElement {
                         type: 'user',
                         content: turn.transcription,
                         timestamp: turn.timestamp,
+                        formattedTimestamp: turn.formattedTimestamp,
                     });
                 }
                 if (turn.ai_response) {
@@ -512,6 +524,7 @@ export class HistoryView extends LitElement {
                         type: 'ai',
                         content: turn.ai_response,
                         timestamp: turn.timestamp,
+                        formattedTimestamp: turn.formattedTimestamp,
                     });
                 }
             });
@@ -546,7 +559,16 @@ export class HistoryView extends LitElement {
             </div>
             <div class="conversation-view">
                 ${messages.length > 0
-                    ? messages.map(message => html` <div class="message ${message.type}">${message.content}</div> `)
+                    ? messages.map(
+                          message => html`
+                              <div class="message ${message.type}">
+                                  ${message.content}
+                                  ${this.isValidHHMMSS(message.formattedTimestamp)
+                                      ? html`<span class="timestamp">${message.formattedTimestamp}</span>`
+                                      : ''}
+                              </div>
+                          `,
+                      )
                     : html`<div class="empty-state">No conversation data available</div>`}
             </div>
         `;

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -42,6 +42,7 @@ function saveConversationTurn(transcription, aiResponse) {
 
     const conversationTurn = {
         timestamp: Date.now(),
+        formattedTimestamp: new Date().toISOString().slice(11, 19),
         transcription: transcription.trim(),
         ai_response: aiResponse.trim(),
     };

--- a/src/utils/prompts.js
+++ b/src/utils/prompts.js
@@ -199,6 +199,30 @@ You: "**Question**: Solve for x: 2x + 5 = 13 **Answer**: x = 4 **Why**: Subtract
         outputInstructions: `**OUTPUT INSTRUCTIONS:**
 Provide direct exam answers in **markdown format**. Include the question text, the correct answer choice, and a brief justification. Focus on efficiency and accuracy. Keep responses **short and to the point**.`,
     },
+
+    colleague: {
+        intro: `You are a helpful colleague ready to offer quick suggestions and clarifications during collaborative work. Provide friendly, professional advice that keeps the team moving forward.`,
+
+        formatRequirements: `**RESPONSE FORMAT REQUIREMENTS:**
+- Keep responses SHORT and CONCISE (1-2 sentences)
+- Use **markdown** for clarity
+- Maintain a friendly, professional tone`,
+
+        searchUsage: `**SEARCH TOOL USAGE:**
+- If teammates reference **recent company news, new tools, or industry updates**, **ALWAYS use Google search** to confirm the latest information
+- After searching, provide a **brief, informed response**`,
+
+        content: `Examples:
+
+Co-worker: "Any quick thoughts on improving our workflow?"
+You: "Let's document the main steps and then divide tasks by priority so we're in sync."
+
+Co-worker: "How should we reply to the client?"
+You: "Thank them for the update and confirm we can deliver by Friday. Does that sound good?"`,
+
+        outputInstructions: `**OUTPUT INSTRUCTIONS:**
+Provide the direct words to say back in **markdown format**. Keep it short, cooperative, and actionable.`,
+    },
 };
 
 function buildSystemPrompt(promptParts, customPrompt = '', googleSearchEnabled = true) {

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -1,0 +1,1 @@
+Feedback resolved: colleague profile added and timestamp validation implemented as requested.


### PR DESCRIPTION
## Summary
- add `colleague` profile to prompt library and selection screen
- store a formatted timestamp when saving conversation turns
- show timestamps in history when they follow `HH:MM:SS`
- document new profile and timestamped history
- add dependency graph, milestone and feedback docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886d2f54558832b84323917a7a03690